### PR TITLE
Add `word-break:break-all` to style

### DIFF
--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -1180,6 +1180,7 @@ a, a:link, a:visited  {
     color: #5b5e5b;
     border: 1px solid rgba(106, 155, 15, 0.1);
     border-radius: 3px;
+    word-break:break-all
 }
 
 .server-node i, .test-node i {


### PR DESCRIPTION
To correctly show long server names without delimeters in booked server list.
