### PR TITLE
Change order of pulled projects

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Change log
 
+## 1.7.1
+* Fix order in which project are pulled. If there was new dependencies in `testing-shared` - they will be included in OnlineDocuments
+
 ## 1.7.0
 * You can use now not only branch, but tags as identificators
 * Ensure, that webserver can be run on `puma` server (Was already included in Gemfile)

--- a/app/server/server_options.rb
+++ b/app/server/server_options.rb
@@ -13,8 +13,8 @@ class ServerOptions
   def create_options
     @teamlab_branch = 'master' if @docs_branch == 'master'
     @docs_branch = 'master' if @teamlab_branch == 'master'
-    command = "cd ~/RubymineProjects/OnlineDocuments && git reset --hard && git pull && git checkout #{@docs_branch} && git pull && bundle install && " \
-        "cd ~/RubymineProjects/SharedFunctional && git reset --hard && git pull && git checkout #{@shared_branch} && git pull && bundle install && " \
+    command = "cd ~/RubymineProjects/SharedFunctional && git reset --hard && git pull && git checkout #{@shared_branch} && git pull && bundle install && " \
+        "cd ~/RubymineProjects/OnlineDocuments && git reset --hard && git pull && git checkout #{@docs_branch} && git pull && bundle install && " \
         "cd ~/RubymineProjects/TeamLab && git reset --hard && git pull && git checkout #{@teamlab_branch} && git pull && bundle install && " \
         "cd ~/RubymineProjects/TeamLabAPI2 && git reset --hard && git pull && git checkout #{@teamlab_api_branch} && git pull && " \
         "#{generate_region_command} "


### PR DESCRIPTION
This will fix probles, that new dependencies in shared will not be
installed in OnlineDocuments, since it will be pulled first
