### PR TITLE
Use `--shm-size` option for `docker run` for increasing it

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 1.9
+## New features
+* Use `--shm-size` option for `docker run` for increasing it. Remove old code for increase shm by runtime.
+Need to use docker v1.10.0 or newer for it (https://github.com/docker/docker/pull/16168)
+
 ## 1.8
 ### New features
 * Test list now shown not only `spec` and `RSpec` folder, but all project folders

--- a/app/server/managers/test_manager.rb
+++ b/app/server/managers/test_manager.rb
@@ -23,8 +23,7 @@ module TestManager
   end
 
   def execute_docker_command(command)
-    shm_increase = 'sudo umount /dev/shm; sudo mount -t tmpfs -o rw,nosuid,nodev,noexec,relatime,size=512M tmpfs /dev/shm;' # TODO: remove after docker implement `-shm` argument https://github.com/docker/docker/issues/2606
-    generate_ssh_command("docker rm -f $(docker ps -a -q); docker pull onlyofficetestingrobot/nct-at-testing-node; docker run --privileged=true onlyofficetestingrobot/nct-at-testing-node bash -c \"#{shm_increase}sudo mount -a; #{command}\"")
+    generate_ssh_command("docker rm -f $(docker ps -a -q); docker pull onlyofficetestingrobot/nct-at-testing-node; docker run --privileged=true --shm-size=512m onlyofficetestingrobot/nct-at-testing-node bash -c \"sudo mount -a; #{command}\"")
   end
 
   def stop_test


### PR DESCRIPTION
Remove old code for increase shm by runtime.
Need to use docker v1.10.0 or newer for it (https://github.com/docker/docker/pull/16168)
