### PR TITLE
Replace several git pulls to single `git pull --all --prune`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,8 @@ You should implement parsing it in your tests, to correctly run tests on customs
 ## Changes
 * Add button for spec file now adds it to beginning of queue, instead of end. Behaviour not changed if add folder
 
+## Fixes
+* Fix problem with checkout of tag and running `git pull` after that
 
 ## 1.8
 ### New features

--- a/app/server/server_options.rb
+++ b/app/server/server_options.rb
@@ -13,10 +13,10 @@ class ServerOptions
   def create_options
     @teamlab_branch = 'master' if @docs_branch == 'master'
     @docs_branch = 'master' if @teamlab_branch == 'master'
-    command = "cd ~/RubymineProjects/SharedFunctional && git reset --hard && git pull && git checkout #{@shared_branch} && git pull && bundle install && " \
-        "cd ~/RubymineProjects/OnlineDocuments && git reset --hard && git pull && git checkout #{@docs_branch} && git pull && bundle install && " \
-        "cd ~/RubymineProjects/TeamLab && git reset --hard && git pull && git checkout #{@teamlab_branch} && git pull && bundle install && " \
-        "cd ~/RubymineProjects/TeamLabAPI2 && git reset --hard && git pull && git checkout #{@teamlab_api_branch} && git pull && " \
+    command = "cd ~/RubymineProjects/SharedFunctional && git reset --hard && git pull --all --prune && git checkout #{@shared_branch} && bundle install && " \
+        "cd ~/RubymineProjects/OnlineDocuments && git reset --hard && git pull --all --prune && git checkout #{@docs_branch} && bundle install && " \
+        "cd ~/RubymineProjects/TeamLab && git reset --hard && git pull --all --prune && git checkout #{@teamlab_branch} && bundle install && " \
+        "cd ~/RubymineProjects/TeamLabAPI2 && git reset --hard && git pull --all --prune && git checkout #{@teamlab_api_branch} && " \
         "#{generate_region_command} "
     command
   end


### PR DESCRIPTION
Without it every repo make `git checkout` of branch and after
that run second `git pull` to fetch changes for specific branch.
But if you use not branch, but tag name in `git checkout` - `git pull`
failed, because you cannot pull if you're on tag.
