### PR TITLE
Remove useless setting @create_portal variable

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ You should implement parsing it in your tests, to correctly run tests on customs
 
 ## Changes
 * Add button for spec file now adds it to beginning of queue, instead of end. Behaviour not changed if add folder
+* Remove setting `@create_portal` flag in `portal_data_docs`. It broke stuff if there is custom portal
 
 ## Fixes
 * Fix problem with checkout of tag and running `git pull` after that

--- a/app/server/server_options.rb
+++ b/app/server/server_options.rb
@@ -22,17 +22,12 @@ class ServerOptions
   end
 
   def generate_region_command
+    region_command = ''
     portal_data_docs = '~/RubymineProjects/OnlineDocuments/data/portal_data.rb'
     portal_data_teamlab = '~/RubymineProjects/TeamLab/Framework/StaticDataTeamLab.rb'
-    create_portal = if @portal_type == 'default'
-                      "sed -i \\\"s/@create_portal = true/@create_portal = false/g\\\" #{portal_data_docs}"
-                    else
-                      "sed -i \\\"s/@create_portal = false/@create_portal = true/g\\\" #{portal_data_docs}"
-                    end
-    region_command = create_portal
     unless @portal_type == 'default'
       region_command +=
-        " && sed -i \\\"s/@create_portal_domain = '.*'/@create_portal_domain = '.#{@portal_type}'/g\\\" #{portal_data_docs} && " \
+        "sed -i \\\"s/@create_portal_domain = '.*'/@create_portal_domain = '.#{@portal_type}'/g\\\" #{portal_data_docs} && " \
         "sed -i \\\"s/@create_portal_region = '.*'/@create_portal_region = '#{@portal_region}'/g\\\" #{portal_data_docs} && " \
         "sed -i \\\"s/@@portal_type = '.*'/@@portal_type = '.#{@portal_type}'/g\\\" #{portal_data_teamlab} && " \
         "sed -i \\\"s/@@server_region = '.*'/@@server_region = '#{@portal_region}'/g\\\" #{portal_data_teamlab} "


### PR DESCRIPTION
It broke serious stuff in document tests if
there is setup custom portal.
It delets all the user file each test.
