### PR TITLE
Fix hanging page issue while pull branches of projects

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@ You should implement parsing it in your tests, to correctly run tests on customs
 * Fix showing `Already up-to-date` in branches list
 * Fix fetching branch info for `TeamLab` project
 * Fix issue with new lin of Server list (#149)
+* Fix hanging page issue while pull branches of projects
 
 ## 1.8
 ### New features

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -744,7 +744,6 @@ function Runner() {
                 _self.selectProject(project);
                 _self.eventToAddTestInQueue(trimmed_data.find('.add-button-file'));
                 _self.eventToAddFolderInQueue(trimmed_data.find('.add-button-folder'));
-                hideSectionOverlay();
             },
             error: function (xhr, type, errorThrown) {
                 ajaxErrorUnlessPageRefresh(xhr, type, errorThrown)
@@ -779,11 +778,12 @@ function Runner() {
         $.ajax({
             url: 'runner/branches',
             context: this,
-            async: false,
+            async: true,
             type: 'GET',
             success: function (data) {
                 _self.setGitReferences($('#docs-branches'), data.doc_branches, data.doc_tags);
                 _self.setGitReferences($('#teamlab-branches'), data.tm_branches, data.tm_tags);
+                hideSectionOverlay();
             },
             error: function (xhr, type, errorThrown) {
                 ajaxErrorUnlessPageRefresh(xhr, type, errorThrown)


### PR DESCRIPTION
Make async calls and hide loading image after longes
operation - pulling branches.