### PR TITLE
Fix minor problem with align of test progress

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@ You should implement parsing it in your tests, to correctly run tests on customs
 * Fix issue with new lin of Server list (#149)
 * Fix hanging page issue while pull branches of projects
 * Fix not hiding overlay for changing branches
+* Do not change position of test progress if user ubook server
 
 ## 1.8
 ### New features

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -409,12 +409,12 @@ function Runner() {
 
     this.showBookedClient = function(userIcon, userName) {
         userIcon.find('span').text(userName);
-        userIcon.show();
+        userIcon.css('visibility', 'visible');
     };
 
     this.hideBookedClient = function(userIcon) {
         userIcon.find('span').text('');
-        userIcon.hide();
+        userIcon.css('visibility', 'hidden');
     };
 
     this.setStatusToServerView = function (server, status) {

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -415,7 +415,6 @@ hr.deliver {
     border: 1px solid rgb(140, 202, 17);
     border-radius: 3px;
     box-shadow: 0 1px 5px 0 #2f2f2f;
-    cursor: pointer;
 }
 
 .server-header .unbook-button, .server-header .book-button {
@@ -423,6 +422,7 @@ hr.deliver {
     width: 15%;
     text-align: center;
     overflow: hidden;
+    cursor: pointer;
 }
 
 .server-header label{
@@ -572,6 +572,7 @@ hr.deliver {
     float: right;
     top: 3px;
     vertical-align: middle;
+    cursor: pointer;
 }
 .server-header .ui-progress {
     display: block;
@@ -614,6 +615,7 @@ hr.deliver {
     float: right;
     margin-top: 3px;
     margin-right: 3px;
+    cursor: help;
 }
 
 .glyphicon {


### PR DESCRIPTION
It server unbooked - icon of user is hided,
and after that position of test progress changes.
Looks like this:
https://cloud.githubusercontent.com/assets/668524/20007666/6bacc0e8-a2ae-11e6-9017-e51e5b010715.png
It not very user friendly, and now position of progress never change