### PR TITLE
Increase shm size to 2 gigabyte

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 ## New features
 * Use `--shm-size` option for `docker run` for increasing it. Remove old code for increase shm by runtime.
 Need to use docker v1.10.0 or newer for it (https://github.com/docker/docker/pull/16168)
+* Increase `shm-size` to 2 gigabyte
 * Docker rm executed containers after finish task
 * Add ability to send custom portal name to spec.  It use enviroment variable `SPEC_SERVER_IP`. 
 You should implement parsing it in your tests, to correctly run tests on customs ip.

--- a/app/server/managers/test_manager.rb
+++ b/app/server/managers/test_manager.rb
@@ -38,7 +38,7 @@ module TestManager
     docker_keys = '--privileged=true '\
                   '-v /mnt/data_share:/mnt/data_share '\
                   '--rm '\
-                  '--shm-size=512m'
+                  '--shm-size=2g'
     'docker rm -f $(docker ps -a -q); '\
     'docker pull onlyofficetestingrobot/nct-at-testing-node; '\
     "docker run #{docker_keys} onlyofficetestingrobot/nct-at-testing-node "\


### PR DESCRIPTION
According to this:
https://bugs.chromium.org/p/chromedriver/issues/detail?id=732#c31
`no such session` error in chromedriver was caused by shm size