### PR TITLE
Fix deprectation warning

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,9 @@
 ### New features
 * Upgrade to rails 5
 
+### Bug fixes
+* Deprecation warning for `config.serve_static_files`
+
 ## 1.10
 ### New features
 * Ability to download log file from `server_history` page

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -14,18 +14,9 @@ Rails.application.configure do
   config.consider_all_requests_local       = true # TODO: disable as soon as all mystic errors are fixed
   config.action_controller.perform_caching = true
 
-  # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.serve_static_files = true
-
-  # Enable Rack::Cache to put a simple HTTP cache in front of your application
-  # Add `rack-cache` to your Gemfile before enabling this.
-  # For large-scale production use, consider using a caching reverse proxy like
-  # NGINX, varnish or squid.
-  # config.action_dispatch.rack_cache = true
-
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static file server for tests with Cache-Control for performance.
-  config.serve_static_files   = true
+  config.public_file_server.enabled = true
   config.static_cache_control = 'public, max-age=3600'
 
   # Show full error reports and disable caching.


### PR DESCRIPTION
```
DEPRECATION WARNING: `config.serve_static_files` is deprecated and will be removed in Rails 5.1.
```