### PR TITLE
Add sorting to server list

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 
 ### Bug fixes
 * Deprecation warning for `config.serve_static_files`
+* Sorting list of booked servers
 
 ## 1.10
 ### New features

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -174,8 +174,9 @@ function Runner() {
     };
 
     this.showBookedServers = function(servers) {
-        for(var i = 0; i < servers.length; i++) {
-            _self.appendServerOnQueue(servers[i]);
+        var sortedServers = servers.sort();
+        for(var i = 0; i < sortedServers.length; i++) {
+            _self.appendServerOnQueue(sortedServers[i]);
         }
     };
 


### PR DESCRIPTION
Fix problem, that booked servers are not sorted.
![image](https://cloud.githubusercontent.com/assets/668524/20925586/e641e38c-bbc8-11e6-89dd-5120c2119ad2.png)
