### PR TITLE
Bring back removed `.log-window` css class

### DIFF
--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -698,6 +698,19 @@ hr.deliver {
     font-weight: bold;
 }
 
+.log-window {
+    margin-top: 2px;
+    border-radius: 3px;
+    box-shadow: inset 0 0 1px 0 rgba(0,0,0,0.7);
+    background: rgba(255,255,255,0.9);
+    font-size: 12px;
+    font-weight: normal;
+    padding: 3px;
+    color: rgba(0,0,0,0.7);
+    height: 85px;
+    overflow: hidden;
+}
+
 .log-opener {
     margin-top: 6px;
     text-align: center;


### PR DESCRIPTION
Without it log window looked like this:
![image](https://cloud.githubusercontent.com/assets/668524/21924703/4af528fe-d98b-11e6-8bc3-2f238b730e9d.png)
