### PR TITLE
Fix server error while calling `servers/show_current_results`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 ### Fixes
 * Fix problem with manual destroying server, booked by other client
 * Do not call `ensure_logs_folder_present` in test env
+* Fix server error while calling `servers/show_current_results` for server which not running tests
 
 ## 1.12
 ### New features

--- a/app/server/server_thread.rb
+++ b/app/server/server_thread.rb
@@ -116,6 +116,7 @@ class ServerThread
   end
 
   def test_name
+    return nil unless @test
     @test[:test_name]
   end
 end


### PR DESCRIPTION
for server which not running tests