### PR TITLE
Fix server error while calling `servers/show_current_results`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 * Fix problem with manual destroying server, booked by other client
 * Do not call `ensure_logs_folder_present` in test env
 * Fix server error while calling `servers/show_current_results` for server which not running tests
+* Fix server error while calling `servers/show_current_results` for non-existing server
 
 ## 1.12
 ### New features

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -33,6 +33,7 @@ class ServersController < ApplicationController
 
   def show_current_results
     server_thread = Runner::Application.config.threads.get_thread_by_name(params['server'])
+    return render plain: "No such server `#{params['server']}`" unless server_thread
     @rspec_result = server_thread.full_results_of_test
     @file_name = server_thread.test_name
 


### PR DESCRIPTION
for non-existing server