### PR TITLE
Fix render `RunnderController#updated_data` in browser

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@
 * Fix server error while calling `servers/show_current_results` for server which not running tests
 * Fix server error while calling `servers/show_current_results` for non-existing server
 * Fix null element while clicking cancel in custom portal field (fix #226)
+* Fix render `RunnderController#updated_data` in browser
 
 ## 1.12
 ### New features

--- a/app/controllers/runner_controller.rb
+++ b/app/controllers/runner_controller.rb
@@ -152,6 +152,7 @@ class RunnerController < ApplicationController
     output_json = output_json.to_json
 
     respond_to do |format|
+      format.html { render json: output_json }
       format.json { render json: output_json }
     end
   end


### PR DESCRIPTION
Cause error like this:
![image](https://cloud.githubusercontent.com/assets/668524/25170955/ed606630-24f4-11e7-8f2e-d9d955fae796.png)
