### PR TITLE
Set default language for spec as `en-US`

### DIFF
--- a/app/client_queue/client_runner_manager.rb
+++ b/app/client_queue/client_runner_manager.rb
@@ -78,7 +78,7 @@ class ClientRunnerManager
   end
 
   def add_test(test, branch, location,
-               spec_language = nil,
+               spec_language = Rails.application.config.default_spec_language,
                to_begin_of_queue: true,
                tm_branch: nil,
                doc_branch: nil)

--- a/config/application.rb
+++ b/config/application.rb
@@ -52,5 +52,6 @@ module Runner
                             exception_recipients: [Rails.application.secrets.admin_email]
                           }
     config.mock_cloud_server = false
+    config.default_spec_language = 'en-US'
   end
 end


### PR DESCRIPTION
Fix #245