### PR TITLE
Precompile assets in production

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
 # Change log
 
 ## master
+### New features
+* Precompile assets in production
 
 ## 1.13
 ### New features

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN mkdir /root/wrata
 WORKDIR /root/wrata
 COPY . /root/wrata
 RUN bundle install
+RUN RAILS_ENV=production rake assets:precompile
 CMD rm -f /root/wrata/tmp/pids/server.pid && \
     RAILS_ENV=production rake db:create db:migrate && \
     SECRET_KEY_BASE=82bac4f58c93c32288273e15afe2b91b171d9d7eb7c17e7f4ce15d7839143caabf9c7093b8b09c84172a1fffb3c2a9cb30c5f38c81c4623364e3915596e5c8c2 \

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,9 +22,6 @@ Rails.application.configure do
   config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
-  # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = true
-
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.
   config.assets.digest = true


### PR DESCRIPTION
Old version complied assets each run
According to:
http://guides.rubyonrails.org/asset_pipeline.html#live-compilation
```
This mode uses more memory, performs more poorly than the default and
is not recommended.
```