### PR TITLE
Possible fix of Connection Pool exceeded

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@
 ### Fix
 * Use `seeds.rb` to set default `SpecLanguage` to `en-US`
 * Fix problems with precompiled image backgrounds
+* Possible fix of Connection Pool exceeded
 
 ## 1.13
 ### New features

--- a/app/server/managers/thread_manager.rb
+++ b/app/server/managers/thread_manager.rb
@@ -20,6 +20,7 @@ module ThreadManager
         init_last_log
         delete_log_file
         delete_html_result
+        ActiveRecord::Base.clear_active_connections!
         @last_log_end = 0
         @test = nil
       end


### PR DESCRIPTION
Connection pool leak caused error like:
`could not obtain a connection from the pool within 5.000 seconds`