### PR TITLE
Show `spec_language` in current running test tooltip

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 * Increase puma threads count
 * Add highlight for files in file-tree
 * Add margin between add-button-file and filename
+* Show `spec_language` in current running test tooltip (fix [#286](https://github.com/ONLYOFFICE/testing-wrata/issues/286))
 
 ### Refactor
 * Remove unused `start-icon`

--- a/app/assets/javascripts/server_update.js
+++ b/app/assets/javascripts/server_update.js
@@ -126,6 +126,7 @@ function setTestNameAndOptions(hidden_elem, test) {
     hidden_elem.find('.time').text(test.time);
     hidden_elem.find('.docs_branch').text('Docs Branch: ' + test.doc_branch);
     hidden_elem.find('.tm_branch').text('OnlyOffice Branch: ' + test.tm_branch);
+    hidden_elem.find('.spec_language').text('Spec Language: ' + test.spec_language);
 }
 
 function showBookedClient(userIcon, userName) {

--- a/app/server/server_thread.rb
+++ b/app/server/server_thread.rb
@@ -72,7 +72,8 @@ class ServerThread
         failed_count: @test_failed_count,
         time: testing_time,
         doc_branch: @test[:doc_branch],
-        tm_branch: @test[:tm_branch]
+        tm_branch: @test[:tm_branch],
+        spec_language: @test[:spec_language]
       }
     end
     if @client && !@server_model.book_client_id.nil?

--- a/app/views/runner/show_servers.erb
+++ b/app/views/runner/show_servers.erb
@@ -31,6 +31,7 @@
             <div class="time">5:43</div>
             <div class="docs_branch">docs_branch: Unknown</div>
             <div class="tm_branch">tm_branch: Unknown</div>
+            <div class="spec_language">SpecLanguage: Unknown</div>
           </span>
         </div>
       </div>


### PR DESCRIPTION
Fix #286