### PR TITLE
Remove path to formatter

### DIFF
--- a/app/server/managers/html_result_manager.rb
+++ b/app/server/managers/html_result_manager.rb
@@ -10,8 +10,7 @@ module HTMLResultManager
   end
 
   def save_to_html
-    # TODO: fix absolute path to formatter
-    " --format HtmlWithPassedTime --require ~/RubymineProjects/SharedFunctional/helpers/rspec/formatter/html_with_passed_time.rb -o #{rspec_html_result_path}"
+    " --format HtmlWithPassedTime -o #{rspec_html_result_path}"
   end
 
   def delete_html_result


### PR DESCRIPTION
Formatter was move out to separate gem in
https://github.com/ONLYOFFICE/testing-shared/pull/464