### PR TITLE
Do not fail if exit code not saved for any reason

### DIFF
--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -13,7 +13,7 @@ class History < ActiveRecord::Base
   # spec execution finished correctly, or something went wrong
   def spec_finished_correctly?
     return true if force_stop?
-    return true if exit_code.zero?
+    return true if exit_code && exit_code.zero?
     total_result.include?('example')
   end
 


### PR DESCRIPTION
After force stop it may be not saved (don't know why)
Without this check there will be crush like this:
```
/root/wrata/app/models/history.rb:16:in `spec_finished_correctly?':
undefined method `zero?' for nil:NilClass (NoMethodError)
```