### PR TITLE
Increase nginx connections timeouts

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -11,6 +11,10 @@ server {
 		proxy_set_header Host $host;
 		proxy_redirect off;
 		proxy_pass http://puma_rails_app;
+		proxy_connect_timeout 600s;
+		proxy_send_timeout 600s;
+		proxy_read_timeout 600s;
+		send_timeout 600s;
 		access_log /var/log/nginx/access.log;
 		error_log /var/log/nginx/error.log;
 	}


### PR DESCRIPTION
Without it some long operation (like Droplet creation)
may fail with error:
```
504 Gateway Time-out
```