### PR TITLE
Fix encoding error while writing log

### DIFF
--- a/app/models/concerns/server_test_out.rb
+++ b/app/models/concerns/server_test_out.rb
@@ -39,7 +39,7 @@ module ServerTestOut
     File.open(log_path, 'a+') do |f|
       f << History::FORCE_STOP_LOG_ENTRY
       f << ServerTestOut::BEGIN_HTML_OUT
-      f << result
+      f << result.force_encoding('ASCII-8BIT').encode('UTF-8')
       f << ServerTestOut::END_HTML_OUT
     end
   end


### PR DESCRIPTION
```
An Encoding::UndefinedConversionError occurred in
runner#stop_all_booked:

"\xD0" from ASCII-8BIT to UTF-8
app/models/concerns/server_test_out.rb:42:in `write'
```