### PR TITLE
Fix opening html result

### DIFF
--- a/app/server/managers/html_result_manager.rb
+++ b/app/server/managers/html_result_manager.rb
@@ -1,3 +1,4 @@
+require 'open-uri'
 module HTMLResultManager
   def result_url
     "http://#{@server_model.address}/#{@server_model.name}.html"


### PR DESCRIPTION
[`open(url)`](https://github.com/ONLYOFFICE/testing-wrata/blob/e4495ad5caa55c3781e337d4fc23721949696388/app/server/managers/html_result_manager.rb#L22) return error without this require
It was broken in:
https://github.com/ONLYOFFICE/testing-wrata/pull/347
Since this gem perform same require