### PR TITLE
Set `RAILS_LOG_TO_STDOUT` in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     depends_on:
       - db
     tty: true
+    environment:
+      RAILS_LOG_TO_STDOUT: "true"
   web:
     image: nginx
     volumes:


### PR DESCRIPTION
So all logs will be aviable via `docker logs`
Before that part of logs was out to `log/production.log`