### PR TITLE
Show overlay for stop operatation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 ### New features
 * Add several new lags to SpecLanguage
 * Destroy only droplet with specified tag
+* Show progress overlay for `runner/stop_current`
 
 ## 1.15.0
 ### New features

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -119,12 +119,18 @@ function Runner() {
         $.ajax({
             url: 'runner/stop_current',
             type: 'POST',
-            async: false,
             data: {
                 'server': server
             },
+            beforeSend: function () {
+                showOverlay('Stopping tests on "' + server + '" servers');
+            },
+            complete: function () {
+                getUpdatedDataFromServer();
+                hideOverlay();
+            },
             success: function () {
-                showInfoAlert('Current test was stopped successfully!');
+                showInfoAlert('Current test on "' + server + '" was stopped!');
             },
             error: function (xhr, type, errorThrown) {
                 ajaxErrorUnlessPageRefresh(xhr, type, errorThrown);
@@ -141,6 +147,7 @@ function Runner() {
                 showOverlay('Stopping tests on all booked servers');
             },
             complete: function () {
+                getUpdatedDataFromServer();
                 hideOverlay();
             },
             success: function () {


### PR DESCRIPTION
Also make stop current async, like `stop_all`
Works great with overlay!
Fix #365 