### PR TITLE
For some reason rails app hungup

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,6 @@
 * Add several new lags to SpecLanguage
 * Destroy only droplet with specified tag
 * Show progress overlay for `runner/stop_current`
-* Update app to Ruby 2.5.0
 
 ## 1.15.0
 ### New features

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.0
+FROM ruby:2.4.3
 
 MAINTAINER Pavel.Lobashov "shockwavenn@gmail.com"
 


### PR DESCRIPTION
Nginx just return 499 error
No errors in logs
Maybe ruby 2.5.0 is the reason, so try to rollback