### PR TITLE
Revert "For some reason rails app hungup"

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 * Add several new lags to SpecLanguage
 * Destroy only droplet with specified tag
 * Show progress overlay for `runner/stop_current`
+* Update app to Ruby 2.5.0
 
 ## 1.15.0
 ### New features

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4.3
+FROM ruby:2.5.0
 
 MAINTAINER Pavel.Lobashov "shockwavenn@gmail.com"
 


### PR DESCRIPTION
Reverts ONLYOFFICE/testing-wrata#369
Seems ruby have nothing to do with it.
Current possible reason - docker.
With docker `17.09.0-ce` everything seems fine for now, but troubles get in `17.12.0-ce`