### PR TITLE
Revert "Replace `Server_destroyer_worker` by `whenever` gem task"

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,6 @@
 * Destroy only droplet with specified tag
 * Show progress overlay for `runner/stop_current`
 * Update app to Ruby 2.5.0
-* Replace `Server_destroyer_worker` by `whenever` gem task
 
 ### Refactor
 * Simplify logic of showing current log in Server window

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@ FROM ruby:2.5.0
 
 MAINTAINER Pavel.Lobashov "shockwavenn@gmail.com"
 
-RUN apt-get update -qq && apt-get install -y cron \
-                                             libpq-dev \
-                                             nodejs
+RUN apt-get update -qq && apt-get install -y libpq-dev nodejs
 COPY ssh/ /root/.ssh/
 RUN chmod 600 /root/.ssh/*
 
@@ -18,9 +16,7 @@ COPY . /root/wrata
 RUN bundle install
 RUN RAILS_ENV=production rake assets:precompile
 ENV RAILS_SERVE_STATIC_FILES=true
-CMD whenever --update-crontab && \
-    cron && \
-    rm -f /root/wrata/tmp/pids/server.pid && \
+CMD rm -f /root/wrata/tmp/pids/server.pid && \
     RAILS_ENV=production rake db:create db:migrate db:seed && \
     SECRET_KEY_BASE=82bac4f58c93c32288273e15afe2b91b171d9d7eb7c17e7f4ce15d7839143caabf9c7093b8b09c84172a1fffb3c2a9cb30c5f38c81c4623364e3915596e5c8c2 \
     bundle exec rails s -p 3000 -b '0.0.0.0' --environment=production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,6 @@ GEM
     builder (3.2.3)
     childprocess (0.8.0)
       ffi (~> 1.0, >= 1.0.11)
-    chronic (0.10.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.0.5)
@@ -259,8 +258,6 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    whenever (0.10.0)
-      chronic (>= 0.6.3)
 
 PLATFORMS
   ruby
@@ -288,7 +285,6 @@ DEPENDENCIES
   rubocop
   scss_lint
   uglifier
-  whenever
 
 BUNDLED WITH
    1.16.1

--- a/app/workers/server_destroyer_worker.rb
+++ b/app/workers/server_destroyer_worker.rb
@@ -1,0 +1,18 @@
+class ServerDestroyerWorker
+  def create_thread
+    @server_destroyer_thread = Thread.new(caller: method(__method__).owner.to_s) do
+      loop do
+        Runner::Application.config.threads.destroy_inactive_servers unless Runner::Application.config.threads.nil?
+        sleep TIME_FOR_UPDATE
+      end
+    end
+  end
+
+  def start_thread
+    if @server_destroyer_thread.nil?
+      create_thread
+    elsif @server_destroyer_thread.alive?
+      @server_destroyer_thread.run if @server_destroyer_thread.stop?
+    end
+  end
+end

--- a/config/initializers/managers.rb
+++ b/config/initializers/managers.rb
@@ -3,4 +3,5 @@ unless File.basename($PROGRAM_NAME) == 'rake'
   Rails.application.config.delayed_runs = DelayedRunManager.new
   Rails.application.config.run_manager = RunnerManagers.new
   Rails.application.config.threads = ServerThreads.new.init_threads
+  Rails.application.config.server_destroyer = ServerDestroyerWorker.new.start_thread
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,6 +1,0 @@
-# docker workaround, see https://github.com/javan/whenever/issues/656#issuecomment-239111064
-ENV.each { |k, v| env(k, v) }
-
-every 1.minute do
-  runner 'Runner::Application.config.threads.destroy_inactive_servers', output: 'log/server_destroyer.log'
-end


### PR DESCRIPTION
Reverts ONLYOFFICE/testing-wrata#372

Server booked status not cleared if server destroeyed by thread
Cause because separate process cannot change status of booked server