### PR TITLE
Fix chrome warning about autocomplete

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 * Destroy only droplet with specified tag
 * Show progress overlay for `runner/stop_current`
 * Update app to Ruby 2.5.0
+* Add autocomplete login description
 
 ### Refactor
 * Simplify logic of showing current log in Server window

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -5,14 +5,14 @@
     <div class="form-group">
       <%= f.label :login, class: 'col-sm-2 control-label' %>
       <div class="col-sm-10">
-        <%= f.text_field :login, class: 'form-control' %>
+        <%= f.text_field :login, class: 'form-control', autocomplete: 'email' %>
       </div>
     </div>
 
     <div class="form-group">
       <%= f.label :password, class: 'col-sm-2 control-label' %>
       <div class="col-sm-10">
-        <%= f.password_field :password, class: 'form-control' %>
+        <%= f.password_field :password, class: 'form-control', autocomplete: 'password' %>
       </div>
     </div>
 


### PR DESCRIPTION
Warning is
`Input elements should have autocomplete attributes`
More at: https://goo.gl/6KgkJg