### PR TITLE
Fix incorrect font face css syntax

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,5 +15,5 @@
 
 @font-face {
     font-family: "OpenSans";
-    url("/assets/OpenSans-Light.ttf") format("ttf"),
+    src: url("/assets/OpenSans-Light.ttf") format("ttf");
 }


### PR DESCRIPTION
This cause error for compiling css assets
According to http://www.css-validator.org/ old syntax was incorrect,
new one is good.