### PR TITLE
Upgrade to nodejs 10

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@
 * Correctly use path for any project name
 * Use `font-awesome` instead of `glyphicons`
 * Upgrade to Bootstrap 4
+* Upgrade to Nodejs 10
 
 ### Fixes
 * Fix silent fail if timeout while restoring image

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ruby:2.5.0
 
 MAINTAINER Pavel.Lobashov "shockwavenn@gmail.com"
 
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get update -qq && apt-get install -y libpq-dev nodejs
 COPY ssh/ /root/.ssh/
 RUN chmod 600 /root/.ssh/*


### PR DESCRIPTION
Without it `rake assets:precompile` cause erorr:
```
Autoprefixer doesn’t support Node v4.8.2. Update it.
```