### PR TITLE
Fix memory leak on clear history

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@
 
 * Update `sprockets` to version 4
 
+### Fixes
+
+* Fix memory leak on clear history
+
 ## 1.17.1 (2019-06-24)
 
 ### Fixes

--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -87,7 +87,7 @@ class ClientsController < ApplicationController
   def clear_history
     client = Client.find_by_login(params[:client])
     history = client.histories
-    history.destroy_all
+    history.in_batches(of: 100).destroy_all
 
     render body: nil
   end

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -46,7 +46,7 @@ class ServersController < ApplicationController
   def clear_history
     server = Server.find_by_name(params['server'])
     history = server.histories
-    history.destroy_all
+    history.in_batches(of: 100).destroy_all
 
     render body: nil
   end


### PR DESCRIPTION
According to https://github.com/rails/rails/issues/22510
`delete_all` load all entries to memory and delete it whole.
Which cause troubles for a lot of entries, wrata.teamlab.info just crash on delete operation