### PR TITLE
Remove `mock_cloud_server` config option

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 ### New features
 
 * Update `sprockets` to version 4
+* Remove `mock_cloud_server` config option
 
 ### Fixes
 

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -60,18 +60,12 @@ class Server < ApplicationRecord
 
   # Set ip info depending of mocking
   def set_ip_info
-    new_address = if Rails.application.config.mock_cloud_server
-                    '127.0.0.1'
-                  else
-                    RunnerManagers.digital_ocean.get_droplet_ip_by_name(name)
-                  end
+    new_address = RunnerManagers.digital_ocean.get_droplet_ip_by_name(name)
     update_column(:address, new_address)
   end
 
   # Start creation and wait for it
   def restore_image_and_wait(server_size)
-    return if Rails.application.config.mock_cloud_server
-
     begin
       RunnerManagers.digital_ocean.restore_image_by_name(EXECUTOR_IMAGE_NAME, name, 'nyc3', server_size, tags: EXECUTOR_TAG)
     rescue StandardError => e
@@ -83,15 +77,11 @@ class Server < ApplicationRecord
 
   # Destroy server and wait for it
   def destroy_and_wait_for_it
-    return if Rails.application.config.mock_cloud_server
-
-    begin
-      check_ability_to_destroy(name)
-      RunnerManagers.digital_ocean.destroy_droplet_by_name(name)
-    rescue StandardError => e
-      update_column(:_status, :created)
-      raise e
-    end
+    check_ability_to_destroy(name)
+    RunnerManagers.digital_ocean.destroy_droplet_by_name(name)
+  rescue StandardError => e
+    update_column(:_status, :created)
+    raise e
   end
 
   # Check if droplet can be destroyed

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,7 +57,6 @@ module Runner
                             sender_address: Rails.application.secrets.gmail_username,
                             exception_recipients: [Rails.application.secrets.admin_email]
                           }
-    config.mock_cloud_server = false
     config.default_spec_language = ['en-US']
     config.node_docker_image = 'onlyofficetestingrobot/nct-at-testing-node:latest'
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,5 +61,4 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
   config.allow_concurrency = true
-  config.mock_cloud_server = true
 end


### PR DESCRIPTION
This option is used very rarely and cause a lot of troubles.
Especially if option is enabled, server created and disabled after.
I think it's better to remove support at all