### PR TITLE
Fix problem with known host with ssh login

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,10 @@
 * Remove ability to login to node via ssh key
 * Actualize Bundler to v.2
 
+### Fixes
+
+* Fix problem with known host with ssh login
+
 ## 1.18.0 (2020-01-30)
 
 ### New features

--- a/app/server/managers/test_manager.rb
+++ b/app/server/managers/test_manager.rb
@@ -39,7 +39,7 @@ module TestManager
 
   def generate_ssh_command(command)
     "sshpass -p #{Rails.application.credentials.ssh_pass} " \
-    'ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no '\
+    'ssh -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null '\
     "#{Rails.application.credentials.ssh_user}@#{@server_model.address} "\
     "<<'SSHCOMMAND'\n#{command}\nSSHCOMMAND"
   end


### PR DESCRIPTION
If node identity changed (for example if this ip already was given
for another node in previos time) ssh will simply disallow login
with error:
```
ssh nct-at@165.22.36.87
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
Someone could be eavesdropping on you right now (man-in-the-middle attack)!
It is also possible that a host key has just been changed.
The fingerprint for the ECDSA key sent by the remote host is
SHA256:L0o/eoijhiopqhg41h
Please contact your system administrator.
Add correct host key in /root/.ssh/known_hosts to get rid of this message.
Offending ECDSA key in /root/.ssh/known_hosts:8
  remove with:
  ssh-keygen -f "/root/.ssh/known_hosts" -R "165.22.36.87"
ECDSA host key for 165.22.36.87 has changed and you have requested strict checking.
Host key verification failed.
```
Old variant just skip error (but still show it) and give
```
Permission denied (publickey,password)
```