### PR TITLE
Fix docker-compose with actual version of postgresql

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@
 
 * Fix problem with known host with ssh login
 * Hide real ssh pass on `server_history` page
+* Fix docker-compose with actual version of postgresql
 
 ### Changes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   db:
     image: postgres
     restart: always
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: 'trust'
   app:
     build: .
     depends_on:


### PR DESCRIPTION
Since recent release of all version of postgresql (9, 10, 11)
starting `docker-compose up db` on empty machine will cause
error about specifying password or adding trust method.
Since this db is only acceseble through docker network it's
save not to use password

See for more details:
https://github.com/docker-library/postgres/issues/681