### PR TITLE
Remove deprecated projects

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,7 @@
 
 * Remove hidden unused files
 * Remove `devise#secret_key` - it's replaced by `RAILS_MASTER_KEY`
+* Remove table columns for deprecated projects
 
 ## 1.18.0 (2020-01-30)
 

--- a/app/models/start_option.rb
+++ b/app/models/start_option.rb
@@ -11,11 +11,7 @@ class StartOption < ApplicationRecord
   end
 
   def create_options
-    command = 'cd ~/RubymineProjects/SharedFunctional && git reset --hard && ' \
-              "git pull --all --prune && git checkout #{shared_branch} && bundle install; " \
-              'cd ~/RubymineProjects/TeamLabAPI2 && git reset --hard && ' \
-              "git pull --all --prune && git checkout #{teamlab_api_branch}; " \
-              "#{update_projects_git(docs_branch)}" \
+    command = "#{update_projects_git(docs_branch)}" \
               "#{generate_region_command}"
     command
   end

--- a/app/server/managers/history_manager.rb
+++ b/app/server/managers/history_manager.rb
@@ -6,8 +6,6 @@ module HistoryManager
     start_options.history = history_db_line
     start_options.docs_branch = options.docs_branch
     start_options.teamlab_branch = options.teamlab_branch
-    start_options.shared_branch = options.shared_branch
-    start_options.teamlab_api_branch = options.teamlab_api_branch
     start_options.portal_type = options.portal_type
     start_options.portal_region = options.portal_region
     start_options.start_command = start_command

--- a/app/views/application/_history_entry.html.erb
+++ b/app/views/application/_history_entry.html.erb
@@ -30,8 +30,6 @@
         <div class="more-options">
           <div>Docs branch: <span class="value"><%= start_option.docs_branch %></span></div>
           <div>Teamlab branch: <span class="value"><%= start_option.teamlab_branch %></span></div>
-          <div>Shared branch: <span class="value"><%= start_option.shared_branch %></span></div>
-          <div>Teamlab API branch: <span class="value"><%= start_option.teamlab_api_branch %></span></div>
           <div>Portal type: <span class="value"><%= portal_type %></span></div>
           <div>Spec browser: <span class="value"><%= start_option.spec_browser %></span></div>
           <div>Spec language: <span class="value"><%= start_option.spec_language %></span></div>

--- a/db/migrate/20200420085308_remove_deprecated_branch_from_start_options.rb
+++ b/db/migrate/20200420085308_remove_deprecated_branch_from_start_options.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class RemoveDeprecatedBranchFromStartOptions < ActiveRecord::Migration[6.0]
+  def up
+    change_table :start_options, bulk: true do |t|
+      t.remove :shared_branch
+      t.remove :teamlab_api_branch
+    end
+  end
+
+  def down
+    change_table :start_options, bulk: true do |t|
+      t.string :shared_branch
+      t.string :teamlab_api_branch
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_11_130732) do
+ActiveRecord::Schema.define(version: 2020_04_20_085308) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,11 +92,11 @@ ActiveRecord::Schema.define(version: 2019_10_11_130732) do
   create_table "start_options", id: :serial, force: :cascade do |t|
     t.string "docs_branch", default: "develop"
     t.string "teamlab_branch", default: "master"
-    t.string "shared_branch", default: "master"
-    t.string "teamlab_api_branch", default: "develop"
     t.string "portal_type", default: "info"
     t.string "portal_region", default: "us"
     t.text "start_command"
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer "history_id"
     t.string "spec_language", default: "en-us"
     t.string "spec_browser"


### PR DESCRIPTION
Those projects not longer used
So no need to store branch info for them, or any other info