### PR TITLE
Fix `/clinets/api_keys` command if key folder not exists

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 ### Fixes
 
 * Retest button now add test with all correct params
+* Fix `/clinets/api_keys` command if key folder not exists
 
 ### Changes
 

--- a/app/views/clients/api_keys.html.erb
+++ b/app/views/clients/api_keys.html.erb
@@ -1,5 +1,6 @@
 <button type="button" onclick="copyKeysToClipboard()">Copy to clipboard</button>
 <pre id="api-keys">
+  mkdir -pv ~/.gem-wrata &&
   cat > ~/.gem-wrata/config.yaml << "EOF"
   cookie: <%= cookies['remember_token'] %>
   csrf_token: <%= form_authenticity_token %>


### PR DESCRIPTION
If folder not exist - old command just failed
Create folder for key before