### PR TITLE
Fix some more css for history table

### DIFF
--- a/app/assets/stylesheets/serverHistory.css.scss
+++ b/app/assets/stylesheets/serverHistory.css.scss
@@ -16,5 +16,6 @@
 }
 
 .history-entry-options-column {
-  width: 3%;
+  overflow-wrap: break-word;
+  width: 5%;
 }


### PR DESCRIPTION
Before:
![Screenshot_20200907_175715](https://user-images.githubusercontent.com/668524/92400169-220b9800-f134-11ea-8d3d-6d22da1ab2f8.png)

After:
![Screenshot_20200907_175732](https://user-images.githubusercontent.com/668524/92400175-246df200-f134-11ea-860e-d50565f90fc9.png)
