### PR TITLE
Fix server restart on `ArgumentError`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@
 * Remove extra unused css rules for `.history-log`
 * Fix css problem with history table is too width
 * Fix error with using non-actual nodejs with `markdownlint`
+* Fix server restart on `ArgumentError` for parsing test result
 
 ### Changes
 

--- a/app/models/concerns/server_test_out.rb
+++ b/app/models/concerns/server_test_out.rb
@@ -29,7 +29,7 @@ module ServerTestOut
     return '' unless match
 
     match[1]
-  rescue Errno::ENOENT => e
+  rescue ArgumentError, Errno::ENOENT => e
     Rails.logger.error("Could not read full log: #{e}")
     ''
   end


### PR DESCRIPTION
Server restart on error like this:
```
[1mTraceback[m (most recent call last):
	7: from /root/wrata/app/server/managers/thread_manager.rb:6:in `block in create_main_thread'
	6: from /root/wrata/app/server/managers/thread_manager.rb:6:in `loop'
	5: from /root/wrata/app/server/managers/thread_manager.rb:16:in `block (2 levels) in create_main_thread'
	4: from /root/wrata/app/server/managers/history_manager.rb:18:in `add_data_to_history'
	3: from /root/wrata/app/server/managers/history_manager.rb:27:in `save_run_history_in_db'
	2: from /root/wrata/app/models/concerns/server_test_out.rb:28:in `final_result_html'
	1: from /root/wrata/app/models/concerns/server_test_out.rb:28:in `match'
/root/wrata/app/models/concerns/server_test_out.rb:28:in `match': [1minvalid byte sequence in UTF-8 ([1;4mArgumentError[m[1m)[m
Exiting
```