### PR TITLE
Fix calling rspec command in gems are outdated

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@
 
 * Add test log to `SpecFailed` mail notification
 
+### Fixes
+
+* Fix call `rspec` command in gem somehow outdated
+
 ### Changes
 
 * Fixes from `rubocop` update to `1.4.0`

--- a/app/server/managers/test_manager.rb
+++ b/app/server/managers/test_manager.rb
@@ -6,7 +6,7 @@ module TestManager
   # Determine which command is used to run test
   # @return [String] command to run test. Empty if not supported.
   def command_executioner(test)
-    return 'rspec' if test.end_with?('_spec.rb')
+    return 'bundle exec rspec' if test.end_with?('_spec.rb')
     return 'ruby' if test.end_with?('rb')
     return 'bash' if test.end_with?('.sh')
 


### PR DESCRIPTION
For some reason in `testing-onlyoffice` project
watir 6.14.0 installed by default, but not the latest
6.17.0
This is not actual problem, but just a result of it
In that scenario rspec command cannot find some gems
and raise errors like those:
```
/root/RubymineProjects/TeamLab/Framework/TestInstance.rb:1:in `require': cannot load such file -- headless (LoadError)
```
But headless gem is installed