### PR TITLE
Fix `sed` error for test start script for custom service url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * Fix error on clicking rspec results for non-rspec files
+* Fix `sed` error for test start script for custom service url
 
 ## 1.21.0 (2020-12-02)
 

--- a/app/models/start_option.rb
+++ b/app/models/start_option.rb
@@ -17,6 +17,7 @@ class StartOption < ApplicationRecord
 
   def generate_region_command
     return '' if portal_type == 'default'
+    return '' if on_custom_portal?
 
     portal_data_docs = '~/RubymineProjects/OnlineDocuments/data/portal_data.rb'
     portal_data_teamlab = '~/RubymineProjects/TeamLab/Framework/StaticDataTeamLab.rb'


### PR DESCRIPTION
There is error in full log of test if test is started on
custom portal, for example `https://nacho.teamlab.info`
```
sed: -e expression #1, char 65: unknown option to `s'
```