### PR TITLE
Reduce production log level to `:warn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * `Servers`, `Run History` and `API Keys` links in user dropdown
   will open in new tab
 * Upgrade to Rails 6.1
+* Reduce production log level to `:warn`
 
 ### Fixes
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
-  config.log_level = :info
+  config.log_level = :warn
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
This allow shorten logs to analyze in case of failure
But may contain some unknown side-effects, like missing
real problems in log
Try to use it for now, but revert in future if some errors
will go unnoticed