### PR TITLE
Fix service failure if `LogManager#read_log` fail with incorrect enco…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 * Fix error on clicking rspec results for non-rspec files
 * Fix `sed` error for test start script for custom service url
+* Fix service failure if `LogManager#read_log` fail with incorrect encoding 
 
 ## 1.21.0 (2020-12-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 * Fix error on clicking rspec results for non-rspec files
 * Fix `sed` error for test start script for custom service url
-* Fix service failure if `LogManager#read_log` fail with incorrect encoding 
+* Fix service failure if `LogManager#read_log` fail with incorrect encoding
 
 ## 1.21.0 (2020-12-02)
 

--- a/app/models/concerns/server_test_out.rb
+++ b/app/models/concerns/server_test_out.rb
@@ -4,6 +4,9 @@ module ServerTestOut
   BEGIN_HTML_OUT = '-----BEGIN HTML OUTPUT-----'
   END_HTML_OUT = '-----END HTML OUTPUT-----'
   FINAL_MATCH_REGEXP = /#{BEGIN_HTML_OUT}(.*)#{END_HTML_OUT}/m.freeze
+  # @return [Array<Exception>] list of exceptions happens on log read failure
+  LOG_READ_FAILURE_EXCEPTIONS = [ArgumentError,
+                                 Errno::ENOENT].freeze
 
   # @return [Stirng] path to log of server
   def log_path
@@ -29,7 +32,7 @@ module ServerTestOut
     return '' unless match
 
     match[1]
-  rescue ArgumentError, Errno::ENOENT => e
+  rescue *ServerTestOut::LOG_READ_FAILURE_EXCEPTIONS => e
     Rails.logger.error("Could not read full log: #{e}")
     ''
   end

--- a/app/server/managers/log_manager.rb
+++ b/app/server/managers/log_manager.rb
@@ -65,7 +65,7 @@ module LogManager
   # @return [Array<String>] server log for current thread
   def read_log
     File.read(@server_model.log_path).lines
-  rescue Errno::ENOENT => e
+  rescue *ServerTestOut::LOG_READ_FAILURE_EXCEPTIONS => e
     Rails.logger.warn("Read file #{@server_model.log_path} is failed with #{e}")
     ['']
   end


### PR DESCRIPTION
…ding

Error like this, seems happened on failure of some node
```
W, [2021-02-04T11:50:03.748104 #234]  WARN -- : read_progress of wrata-staging-11 is failed with Failed to open TCP connection to 138.197.11.103:80 (Connection refused - connect(2) for "138.197.11.103" port 80)
E, [2021-02-04T13:46:44.412302 #234] ERROR -- : Could not read full log: invalid byte sequence in UTF-8
...
/usr/local/bundle/gems/activerecord-6.1.1/lib/active_record/connection_adapters/postgresql_adapter.rb:678:in `exec_params': ERROR:  invalid byte
```

![image](https://user-images.githubusercontent.com/668524/106911090-e7258480-6712-11eb-8407-010b90134c71.png)

Similar to https://github.com/ONLYOFFICE/testing-wrata/pull/839, so both exception are merged in one array