### PR TITLE
Send full region string (like `com us`) in `SPEC_REGION` env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Add `login` field to api config file page
 
+### Changes
+
+* Send full region string (like `com us`) in `SPEC_REGION` env
+
 ## 1.22.0 (2021-04-05)
 
 ### New Features

--- a/app/server/managers/test_manager.rb
+++ b/app/server/managers/test_manager.rb
@@ -19,7 +19,7 @@ module TestManager
   def env_variables_options(options)
     env_variables = 'export DISPLAY=:0.0'
     env_variables += " && export SPEC_BROWSER='#{options.spec_browser}'" unless options.spec_browser == SpecBrowser::DEFAULT
-    env_variables += " && export SPEC_REGION='#{options.portal_type}'"
+    env_variables += " && export SPEC_REGION='#{options.server_location}'"
     env_variables += " && export SPEC_LANGUAGE='#{options.spec_language}'"
     env_variables += " && export SPEC_SERVER_IP='#{options.portal_type}'" if options.on_custom_portal?
     env_variables


### PR DESCRIPTION
Fix #990

Before this change - there is no way to check via env variable
is it `com us` or `com eu`, just `com` in `SPEC_REGION`