### PR TITLE
Fix broken `DelayRun` change time methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Fixes
+
+* Fix broken `DelayRun` change time methods
+
 ## 1.24.0 (2021-06-08)
 
 ### New Features

--- a/app/workers/delayed_run_manager.rb
+++ b/app/workers/delayed_run_manager.rb
@@ -57,4 +57,17 @@ class DelayedRunManager
     init_runs_from_db
     run
   end
+
+  # Update DelayRun properties
+  # @param [ActionController::Parameters] props to update
+  # @return [Boolean] is update successful
+  def update(props)
+    run = DelayedRun.find(props['id'])
+    run.method = props['method']
+    run.location = props['location']
+    run.start_time = props['start_time']
+    run.next_start = props['start_time']
+    init_runs_from_db
+    run.save
+  end
 end


### PR DESCRIPTION
Method was removed by mistake [here](https://github.com/ONLYOFFICE/testing-wrata/pull/612)

Error look liked this:
![image](https://user-images.githubusercontent.com/668524/121696860-2acf3700-cad5-11eb-97c8-926fabf6fdd6.png)

```
undefined method `update' for #, #, #, #, #, #, #, #, #, #]>, @run_scan_thread=#>
```
