### PR TITLE
Fix ApiKeys command on Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Add `sentry` support
 
+### Fixes
+
+* Fix ApiKeys command on Firefox
+
 ## 1.24.1 (2021-06-11)
 
 ### Fixes

--- a/app/assets/stylesheets/apiKeys.css.scss
+++ b/app/assets/stylesheets/apiKeys.css.scss
@@ -1,4 +1,4 @@
 #api-keys {
-  user-select: auto;
+  user-select: all;
   white-space: pre-line;
 }

--- a/app/views/clients/api_keys.html.erb
+++ b/app/views/clients/api_keys.html.erb
@@ -1,11 +1,11 @@
 <button type="button" onclick="copyKeysToClipboard()">Copy to clipboard</button>
 <pre id="api-keys">
-  mkdir -pv ~/.gem-wrata &&
-  cat > ~/.gem-wrata/config.yaml << "EOF"
-  login: <%= current_client.login %>
-  cookie: <%= cookies['remember_token'] %>
-  csrf_token: <%= form_authenticity_token %>
-  uri: <%= request.base_url %>
-  wrata_session: <%= cookies['_runner_session'] %>
-  EOF
+mkdir -pv ~/.gem-wrata &&
+cat > ~/.gem-wrata/config.yaml << "EOF"
+login: <%= current_client.login %>
+cookie: <%= cookies['remember_token'] %>
+csrf_token: <%= form_authenticity_token %>
+uri: <%= request.base_url %>
+wrata_session: <%= cookies['_runner_session'] %>
+EOF
 </pre>


### PR DESCRIPTION
It's quite hard to allow copying of this command
But current code allow safe selection of this command