### PR TITLE
Use `alpine` as base image for app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 * Fix ApiKeys command on Firefox
 * Do not hard crash if some user is lost for DelayRun
 
+### Changes
+
+* Use `alpine` as base image for app
+
 ## 1.24.1 (2021-06-11)
 
 ### Fixes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM ruby:3.0.2
+FROM ruby:3.0.2-alpine
 
 MAINTAINER Pavel.Lobashov "shockwavenn@gmail.com"
 
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
-RUN apt-get update -qq && apt-get install -y libpq-dev \
-                                             nodejs \
-                                             sshpass
+RUN apk add --update build-base \
+                     nodejs \
+                     openssh-client \
+                     postgresql-dev \
+                     sshpass \
+                     tzdata
 WORKDIR /tmp
 COPY Gemfile* /tmp/
 RUN gem install bundler

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,8 @@ services:
     image: nginx:alpine
     volumes:
       # For local compose uncomment volume below and comment `./nginx-ssl.conf`
-      # - "./nginx.conf:/etc/nginx/conf.d/default.conf"
-      - "./nginx-ssl.conf:/etc/nginx/conf.d/default.conf"
+      - "./nginx.conf:/etc/nginx/conf.d/default.conf"
+#      - "./nginx-ssl.conf:/etc/nginx/conf.d/default.conf"
       - ./certs:/etc/nginx/certs
     depends_on:
       - app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,8 @@ services:
     image: nginx:alpine
     volumes:
       # For local compose uncomment volume below and comment `./nginx-ssl.conf`
-      - "./nginx.conf:/etc/nginx/conf.d/default.conf"
-#      - "./nginx-ssl.conf:/etc/nginx/conf.d/default.conf"
+#      - "./nginx.conf:/etc/nginx/conf.d/default.conf"
+      - "./nginx-ssl.conf:/etc/nginx/conf.d/default.conf"
       - ./certs:/etc/nginx/certs
     depends_on:
       - app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     image: nginx:alpine
     volumes:
       # For local compose uncomment volume below and comment `./nginx-ssl.conf`
-#      - "./nginx.conf:/etc/nginx/conf.d/default.conf"
+      # - "./nginx.conf:/etc/nginx/conf.d/default.conf"
       - "./nginx-ssl.conf:/etc/nginx/conf.d/default.conf"
       - ./certs:/etc/nginx/certs
     depends_on:


### PR DESCRIPTION
This reduce image size by 44% by 349 mb

```
$ docker images
REPOSITORY   TAG            IMAGE ID       CREATED         SIZE
ubuntu       latest         07651960da8c   5 seconds ago   1.13GB
alpine       latest         ba0d9ecc2d1c   3 minutes ago   781MB
```