### PR TITLE
Fix failure when `EOFError` happened during html result read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Fixes
+
+* Fix failure when `EOFError` happened during html result read
+
 ### Changes
 
 * Do not show detailed stack of error in production

--- a/app/controllers/concerns/server_thread_methods/html_result_manager.rb
+++ b/app/controllers/concerns/server_thread_methods/html_result_manager.rb
@@ -5,7 +5,8 @@ require 'open-uri'
 module ServerThreadMethods
   module HtmlResultManager
     # @return [Array, Exception] exceptions which may occur if something wrong with reading status
-    READ_STATUS_EXCEPTIONS = [Errno::ECONNREFUSED,
+    READ_STATUS_EXCEPTIONS = [EOFError,
+                              Errno::ECONNREFUSED,
                               Errno::ECONNRESET,
                               Errno::EHOSTUNREACH,
                               Net::OpenTimeout,


### PR DESCRIPTION
Program crashed with something like this in logs:
```
/usr/local/lib/ruby/3.0.0/net/protocol.rb:227:in `rbuf_fill': ^[[1mend of file reached (^[[1;4mEOFError^[[m^[[1m)^[[m
        from /usr/local/lib/ruby/3.0.0/net/protocol.rb:193:in `readuntil'
        from /usr/local/lib/ruby/3.0.0/net/protocol.rb:203:in `readline'
        from /usr/local/lib/ruby/3.0.0/net/http/response.rb:42:in `read_status_line'
        from /usr/local/lib/ruby/3.0.0/net/http/response.rb:31:in `read_new'
        from /usr/local/lib/ruby/3.0.0/net/http.rb:1557:in `block in transport_request'
        from /usr/local/lib/ruby/3.0.0/net/http.rb:1548:in `catch'
        from /usr/local/lib/ruby/3.0.0/net/http.rb:1548:in `transport_request'
        from /usr/local/lib/ruby/3.0.0/net/http.rb:1521:in `request'
        from /usr/local/lib/ruby/3.0.0/net/http.rb:1514:in `block in request'
        from /usr/local/lib/ruby/3.0.0/net/http.rb:960:in `start'
        from /usr/local/lib/ruby/3.0.0/net/http.rb:1512:in `request'
        from /usr/local/lib/ruby/3.0.0/net/http.rb:1436:in `request_head'
        from /root/wrata/app/controllers/concerns/server_thread_methods/html_result_manager.rb:21:in `html_progress_exist?'
        from /root/wrata/app/controllers/concerns/server_thread_methods/html_result_manager.rb:32:in `read_progress'
        from /root/wrata/app/controllers/concerns/server_thread_methods/html_result_manager.rb:42:in `test_metadata'
        from /root/wrata/app/controllers/concerns/server_thread_methods/html_result_manager.rb:49:in `block (2 levels) in create_progress_scan_thread'
        from /root/wrata/app/controllers/concerns/server_thread_methods/html_result_manager.rb:47:in `loop'
        from /root/wrata/app/controllers/concerns/server_thread_methods/html_result_manager.rb:47:in `block in create_progress_scan_thread'
Exiting
/usr/local/lib/ruby/3.0.0/net/protocol.rb:227:in `rbuf_fill': ^[[1mend of file reached (^[[1;4mEOFError^[[m^[[1m)^[[m
        from /usr/local/lib/ruby/3.0.0/net/protocol.rb:193:in `readuntil'
        from /usr/local/lib/ruby/3.0.0/net/protocol.rb:203:in `readline'
        from /usr/local/lib/ruby/3.0.0/net/http/response.rb:42:in `read_status_line'
        from /usr/local/lib/ruby/3.0.0/net/http/response.rb:31:in `read_new'
        from /usr/local/lib/ruby/3.0.0/net/http.rb:1557:in `block in transport_request'
        from /usr/local/lib/ruby/3.0.0/net/http.rb:1548:in `catch'
        from /usr/local/lib/ruby/3.0.0/net/http.rb:1548:in `transport_request'
        from /usr/local/lib/ruby/3.0.0/net/http.rb:1521:in `request'
        from /usr/local/lib/ruby/3.0.0/net/http.rb:1514:in `block in request'
        from /usr/local/lib/ruby/3.0.0/net/http.rb:960:in `start'
        from /usr/local/lib/ruby/3.0.0/net/http.rb:1512:in `request'
        from /usr/local/lib/ruby/3.0.0/net/http.rb:1436:in `request_head'
        from /root/wrata/app/controllers/concerns/server_thread_methods/html_result_manager.rb:21:in `html_progress_exist?'
        from /root/wrata/app/controllers/concerns/server_thread_methods/html_result_manager.rb:32:in `read_progress'
        from /root/wrata/app/controllers/concerns/server_thread_methods/html_result_manager.rb:42:in `test_metadata'
        from /root/wrata/app/controllers/concerns/server_thread_methods/html_result_manager.rb:49:in `block (2 levels) in create_progress_scan_thread'
        from /root/wrata/app/controllers/concerns/server_thread_methods/html_result_manager.rb:47:in `loop'
        from /root/wrata/app/controllers/concerns/server_thread_methods/html_result_manager.rb:47:in `block in create_progress_scan_thread'

```

Not sure why this happened but give this fix a try