### PR TITLE
Migrate autoloader to `:zeitwerk`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fix migration issues after upgrade `rubocop-rspec` to `v2.13.0`
 * Remove `ruby-2.7` from CI, since we use `ruby-3.0` for base
 * Use `ruby:3.1.0-alpine` as base image
+* Migrate autoloader to `:zeitwerk`
 
 ### Fixes
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,7 @@ module Runner
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
+    config.autoloader = :zeitwerk
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -15,7 +15,7 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  config.eager_load = ENV['CI'].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true

--- a/config/initializers/managers.rb
+++ b/config/initializers/managers.rb
@@ -12,10 +12,12 @@ rescue *DB_NOT_INITIALIZED_EXCEPTIONS
   false
 end
 
-if db_initialized?
-  Rails.application.config.threads = ServerThreads.new.init_threads
-  Rails.application.config.delayed_runs = DelayedRunManager.new
-  Rails.application.config.run_manager = RunnerManagers.new
-  Rails.application.config.server_destroyer = ServerDestroyerWorker.new.start_thread
-  Rails.application.config.queue_checker = QueueCheckerWorker.new.start_thread
+Rails.application.config.to_prepare do
+  if db_initialized?
+    Rails.application.config.threads = ServerThreads.new.init_threads
+    Rails.application.config.delayed_runs = DelayedRunManager.new
+    Rails.application.config.run_manager = RunnerManagers.new
+    Rails.application.config.server_destroyer = ServerDestroyerWorker.new.start_thread
+    Rails.application.config.queue_checker = QueueCheckerWorker.new.start_thread
+  end
 end


### PR DESCRIPTION
This is needed in rails v7 because it's default now