### PR TITLE
Actualize `nodejs` version in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -57,6 +57,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
+        with:
+          node-version: '16'
       - name: markdownlint check
         run: |
           npm install -g markdownlint-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Use `ruby:3.1.0-alpine` as base image
 * Migrate autoloader to `:zeitwerk`
 * Update rails framework default from v5.1 to v6.1
+* Actualize `nodejs` version in CI
 
 ### Fixes
 


### PR DESCRIPTION
Without it latest version of `markdownlint-cli` is failing