### PR TITLE
Fix almost all non-GET/POST request with require of `jquery-ujs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Do not crash frontend if Initializers are not loaded
 * Fix `rubocop-1.28.1` code issues
 
-## Fixes
+### Fixes
 
 * Fix almost all non-GET/POST request with require of `jquery-ujs`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,20 @@
 
 ## master (unreleased)
 
-## New Features
+### New Features
 
 * Add `Queue#add_tests` POST endpoint
 * Migrate to `WebPacker`
 
-## Changes
+### Changes
 
 * Do not fail if GitHub is not initialized for some reason
 * Do not crash frontend if Initializers are not loaded
 * Fix `rubocop-1.28.1` code issues
+
+## Fixes
+
+* Fix almost all non-GET/POST request with require of `jquery-ujs`
 
 ## 1.27.0 (2022-03-31)
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,4 +1,5 @@
 require('jquery-ui');
+import {} from 'jquery-ujs'
 import 'bootstrap/dist/js/bootstrap';
 global.bootbox = require('bootbox');
 

--- a/app/javascript/src/main.js
+++ b/app/javascript/src/main.js
@@ -54,12 +54,6 @@ window.trim_data = function(data) {
 }
 
 window.Runner = function() {
-    $.ajaxSetup({
-        headers: {
-            'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
-        }
-    });
-
     var _self = this;
     var testListUpdating = false;
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "bootstrap": "^5.1.3",
     "jquery": "^3.6.0",
     "jquery-ui-dist": "^1.13.1",
+    "jquery-ujs": "^1.2.3",
     "webpack": "^4.46.0",
     "webpack-cli": "^4.9.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3948,6 +3948,11 @@ jquery-ui-dist@^1.13.1:
   dependencies:
     jquery ">=1.8.0 <4.0.0"
 
+jquery-ujs@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/jquery-ujs/-/jquery-ujs-1.2.3.tgz#dcac6026ab7268e5ee41faf9d31c997cd4ddd603"
+  integrity sha512-59wvfx5vcCTHMeQT1/OwFiAj+UffLIwjRIoXdpO7Z7BCFGepzq9T9oLVeoItjTqjoXfUrHJvV7QU6pUR+UzOoA==
+
 "jquery@>=1.8.0 <4.0.0", jquery@^3.5.1, jquery@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"


### PR DESCRIPTION
Without this lib all DELETE requests result in CSRF verification error
Because this lib add it's verification by default
So explicit line is not needed any more