### PR TITLE
Fix language bar position on 1366x768 screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Fix failure on opening test list on history page
 * Fix typo in html structure
 * Fix incorrect font assets path
+* Fix language bar position on 1366x768 screen
 
 ## 1.27.0 (2022-03-31)
 

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -711,7 +711,7 @@ input[type="checkbox"].folder-input + label {
   min-height: 60px;
   padding: 12px;
   position: relative;
-  width: 80%;
+  width: 75%;
 }
 
 label {


### PR DESCRIPTION
Should fix situation like this:
![image](https://user-images.githubusercontent.com/668524/178772270-9d363034-be68-4a7b-b910-4c6eb3007a59.png)
