### PR TITLE
Remove extra docker step to install bundler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Remove useless bundler caching from Dockerfile
 * Dramatically reduce docker image size by using multistage build
 * Fix `rubocop-capybara-2.20.0` warnings
+* Remove extra docker step to install bundler
 
 ### Fixes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ RUN apk add --no-cache build-base \
                        yarn
 WORKDIR /root/wrata
 COPY . /root/wrata
-RUN gem install bundler && \
-    bundle config set without 'development test' && \
+RUN bundle config set without 'development test' && \
     bundle install && \
     yarn install
 RUN rake assets:precompile


### PR DESCRIPTION
For some time bundle by itself knows which version to install, fetching this info from Gemfile.lock