### PR TITLE
Actualize `rails_helper` to fix Rails warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Dramatically reduce docker image size by using multistage build
 * Fix `rubocop-capybara-2.20.0` warnings
 * Remove extra docker step to install bundler
+* Actualize `rails_helper` to fix Rails warnings
 
 ### Fixes
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,7 +26,7 @@ Capybara.javascript_driver = :selenium_headless
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+# Rails.root.glob('spec/support/**/*.rb').sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -37,7 +37,9 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = Rails.root.join('spec/fixtures').to_s
+  config.fixture_paths = [
+    Rails.root.join('spec/fixtures')
+  ]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
This fix #1890
Config fixed via running `rails generate rspec:install`