### PR TITLE
Fix missing `public/pack` directory in Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 ### Fixes
 
 * Fix log spam for `git describe` for shallow copy of repo
+* Fix missing `public/pack` directory in Docker image
 
 ## v1.30.0 (2022-10-31)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,5 @@ RUN apk add --no-cache git \
 COPY . /root/wrata
 WORKDIR /root/wrata
 COPY --from=builder /usr/local/bundle /usr/local/bundle
-COPY --from=builder /root/wrata/public/assets /root/wrata/public/assets
+COPY --from=builder /root/wrata/public /root/wrata/public
 CMD ["sh", "entrypoint.sh"]


### PR DESCRIPTION
Possible fix for https://github.com/ONLYOFFICE/testing-wrata/issues/2103

Broken in https://github.com/ONLYOFFICE/testing-wrata/pull/1825