### PR TITLE
Fix warning for `docker build` about case of `AS` statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 * Fix log spam for `git describe` for shallow copy of repo
 * Fix missing `public/pack` directory in Docker image
+* Fix warning for `docker build` about case of `AS` statement
 
 ## v1.30.0 (2022-10-31)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3.4-alpine as builder
+FROM ruby:3.3.4-alpine AS builder
 
 LABEL maintainer="shockwavenn@gmail.com"
 # To fix Error: error:0308010C:digital envelope routines::unsupported


### PR DESCRIPTION
```
$ docker build .
[+] Building 1.1s (3/3) FINISHED                                                                                                                                              docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                    0.0s
 => => transferring dockerfile: 1.12kB                                                                                                                                                  0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1) 
```