### PR TITLE
Remove obsolete `version` field from `docker-compose.yml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Actualize JS dependencies
 * Update rubocop config to support v3 of `rubocop-rspec`
 * Increase image restore check interval to reduce DO api load
+* Remove obsolete `version` field from `docker-compose.yml`
 
 ### Fixes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   db:
     image: postgres


### PR DESCRIPTION
```
$ docker compose up
WARN[0000] /testing-wrata/docker-compose.yml: `version` is obsolete 
```